### PR TITLE
using assert panic instead of bool

### DIFF
--- a/src/most.rs
+++ b/src/most.rs
@@ -1,6 +1,7 @@
 use crate::error::Timeout;
 use super::backend::Backend;
 use std::time::{Duration, Instant};
+use std::panic::{AssertUnwindSafe, self};
 
 pub struct MostWait<'a> {
     duration: Duration,
@@ -49,12 +50,28 @@ impl<'a> MostWait<'a> {
         }
         self
     }
+
+    pub fn until_no_panic(&mut self, f: impl Fn()) -> &Self {
+        let now = Instant::now();
+        let mut result = panic::catch_unwind(AssertUnwindSafe(|| f()));
+        while result.is_err() {
+            result = panic::catch_unwind(AssertUnwindSafe(|| f()));
+            let elapsed = now.elapsed();
+            if elapsed > self.duration {
+                f();
+                break;
+            }
+            std::thread::sleep(self.backend.interval);
+        }
+        self
+    }
 }
 
 #[cfg(test)]
 mod most_test {
     use std::sync::atomic::{AtomicUsize, Ordering};
     use std::sync::Arc;
+    use std::{thread, time};
     use std::time::Duration;
 
     #[test]
@@ -67,6 +84,21 @@ mod most_test {
             }
         });
         super::at_most(Duration::from_millis(100)).until(|| counter.load(Ordering::SeqCst) > 10);
+    }
+
+    #[test]
+    #[should_panic]
+    fn at_most_using_assert() {
+        let counter = Arc::new(AtomicUsize::new(5));
+        let tcounter = counter.clone();
+        std::thread::spawn(move || {
+            while tcounter.load(Ordering::SeqCst) < 15 {
+                let ten_millis = time::Duration::from_millis(10);
+                thread::sleep(ten_millis);
+                tcounter.fetch_add(1, Ordering::SeqCst);
+            }
+        });
+        super::at_most(Duration::from_millis(1000)).until_no_panic(|| assert!(counter.load(Ordering::SeqCst) < 3));
     }
 
     #[test]


### PR DESCRIPTION
test using bool:
```
#[test]
pub fn await_test_no_assert() {
    let counter = Arc::new(AtomicUsize::new(5));
    let tcounter = counter.clone();
    std::thread::spawn(move || {
        while tcounter.load(Ordering::SeqCst) < 15 {
            let ten_millis = time::Duration::from_millis(10);
            thread::sleep(ten_millis);
            tcounter.fetch_add(1, Ordering::SeqCst);
        }
    });
    awaitility::at_most(Duration::from_millis(1000)).until(|| {
        counter.load(Ordering::SeqCst) < 2
    });
}
```
when failed the output is :
```
---- await_test_no_assert stdout ----
thread 'await_test_no_assert' panicked at 'Condition not satisfied after 1.0545899s. ', D:\programming\awaitility-master\src\backend.rs:34:36
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


test rely on assert panic instead of bool
```
#[test]
pub fn await_test_using_assert() {
    let counter = Arc::new(AtomicUsize::new(5));
    let tcounter = counter.clone();
    std::thread::spawn(move || {
        while tcounter.load(Ordering::SeqCst) < 100 {
            let ten_millis = time::Duration::from_millis(10);
            thread::sleep(ten_millis);
            tcounter.fetch_add(1, Ordering::SeqCst);
        }
    });
    awaitility::at_most(Duration::from_millis(1000)).until_no_panic(|| {
        assert!(counter.load(Ordering::SeqCst) < 2);
    });
}
```
when failed the output:
```
---- await_test_using_assert stdout ----
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9
thread 'await_test_using_assert' panicked at 'assertion failed: counter.load(Ordering::SeqCst) < 2', tests\integretion_tests.rs:29:9


failures:
    await_test_using_assert
```


**the latter one is more user-friendly to developers**